### PR TITLE
Fix service typo and update imports

### DIFF
--- a/src/app/components/characters/characters.component.ts
+++ b/src/app/components/characters/characters.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Character } from '../../interfaces/character';
-import { CharcaterService } from '../../services/charcater.service';
+import { CharacterService } from '../../services/character.service';
 
 @Component({
   selector: 'app-characters',
@@ -13,7 +13,7 @@ export class CharactersComponent implements OnInit {
   public episodeId: number | null = null;
 
   constructor(
-    private charcaterService: CharcaterService,
+    private charcaterService: CharacterService,
     private route: ActivatedRoute
   ) {}
 

--- a/src/app/components/episodes/espisodes.component.ts
+++ b/src/app/components/episodes/espisodes.component.ts
@@ -3,7 +3,7 @@ import { EpisodeService } from '../../services/episode.service';
 import { Episode } from '../../interfaces/episode';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
-import { CharcaterService } from '../../services/charcater.service';
+import { CharacterService } from '../../services/character.service';
 import { Router } from '@angular/router';
 
 
@@ -17,7 +17,7 @@ export class EpisodesComponent implements OnInit {
   public dataSource!: MatTableDataSource<Episode>;
   @ViewChild(MatPaginator, {static: true}) paginator!: MatPaginator;
 
-  constructor(private episodeService: EpisodeService, private characterService: CharcaterService, private router: Router) {}
+  constructor(private episodeService: EpisodeService, private characterService: CharacterService, private router: Router) {}
   ngOnInit(): void {
     this.getEpisodes();
   }

--- a/src/app/services/character.service.ts
+++ b/src/app/services/character.service.ts
@@ -6,7 +6,7 @@ import { Character } from '../interfaces/character';
 @Injectable({
   providedIn: 'root'
 })
-export class CharcaterService {
+export class CharacterService {
 
   private apiUrl = 'https://rickandmortyapi.com/api';
 


### PR DESCRIPTION
## Summary
- rename `charcater.service.ts` to `character.service.ts`
- update the service class name to `CharacterService`
- fix references in `CharactersComponent` and `EpisodesComponent`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b20327a388324a82ba69064f166d5